### PR TITLE
Handle "fatal: Unable to negotiate with" log message.

### DIFF
--- a/bruteforceblocker.pl
+++ b/bruteforceblocker.pl
@@ -82,7 +82,8 @@ while (<>) {
 	/.*Did not receive identification string from ($work->{ipv4}|$work->{ipv6}|$work->{fqdn})$/i ||
 	/.*Bad protocol version identification .* from ($work->{ipv4}|$work->{ipv6}|$work->{fqdn})$/i ||
 	/.*User.*from ($work->{ipv4}|$work->{ipv6}|$work->{fqdn}) not allowed because.*/i ||
-	/.*error: maximum authentication attempts exceeded for.*from ($work->{ipv4}|$work->{ipv6}|$work->{fqdn}).*/i) {
+	/.*error: maximum authentication attempts exceeded for.*from ($work->{ipv4}|$work->{ipv6}|$work->{fqdn}).*/i ||
+	/.*fatal: Unable to negotiate with ($work->{ipv4}|$work->{ipv6}|$work->{fqdn}).*/i) {
 
 	my $IP = $1;
 	if ($IP =~ /$work->{fqdn}/i) {


### PR DESCRIPTION
Add pattern of regular expression to handle log message as following:

> Jan 31 19:29:39 ssh-host sshd[37665]: fatal: Unable to negotiate with 10.0.0.1 port 48308: no matching host key type found. Their offer: ecdsa-sha2-nistp384 [preauth]
