### PR TITLE
Update bruteforceblocker.pl to chase CNAMEs in PTR requests.

### DIFF
--- a/bruteforceblocker.pl
+++ b/bruteforceblocker.pl
@@ -127,7 +127,12 @@ sub block {
     my ($IP) = shift or die "Need IP!\n";
 
     my $query = $res->search($IP, "PTR");
-    my $RDNS = $query ? ($query->answer)[0]->ptrdname : "not resolved";
+	
+	while ($query && ($query->answer)[0]->type eq "CNAME") {
+		$query = $res->search(($query->answer)[0]->cname, "PTR");
+	}
+	
+    my $RDNS = ($query && ($query->answer)[0]->type eq "PTR") ? ($query->answer)[0]->ptrdname : "not resolved";
 
     if ($timea{$IP} && ($timea{$IP} < time - $cfg->{timeout})) {
 	syslog('notice', "resetting $IP ($RDNS) count, since it wasn't active for more than $cfg->{timeout} seconds") if $cfg->{debug};


### PR DESCRIPTION
Figured out how to do this as a pull request - first time for me using this particular tool.

If the block subroutine in bruteforceblocker encounters a CNAME instead of a PTR when it's trying to do the reverse lookup, it crashes the instance.

This fix correctly chases CNAME records returned when doing PTR queries, and also has a bit of belt-n-suspenders if something besides a CNAME or PTR is returned as resource record 0 in the response.